### PR TITLE
fix: data-theme attribute on wrong element

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="valentine">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover" data-theme="valentine">
+	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>


### PR DESCRIPTION
Hey there! Nice boilerplate

I opened this pull request to fix a small error where data-theme attribute is on the body tag of the html, but on the DaisyUI doc it says that it should be on the html tag.

https://daisyui.com/docs/themes